### PR TITLE
Fix "Open Drawer" button locator and add assertion for "Your Cart" title

### DIFF
--- a/playwright/e2e/cart-drawer-open-close.spec.ts
+++ b/playwright/e2e/cart-drawer-open-close.spec.ts
@@ -4,12 +4,13 @@ test('should open and close cart drawer', async ({ page }) => {
   await page.goto('/');
 
   const drawer = page.getByRole('dialog');
-  const openButton =  page.locator('button:has-text("Open drawer")').first();
+  const drawerTitle = page.getByRole('dialog').getByRole('heading', {name: 'Your Cart'});
+  const openDrawerButton =  page.locator('._miniGrid_1jydu_133').getByRole('button', { name: 'Open drawer' })
   const closeButton = page.getByRole('button', { name: 'Close cart' });
   await expect(drawer).toBeHidden();
-  await openButton.click();
+  await openDrawerButton.click();
   await expect(drawer).toBeVisible();
-
+  await expect(drawerTitle).toBeVisible();
   await closeButton.click();
   await expect(drawer).toBeHidden();
 });


### PR DESCRIPTION
Fixed OpenDrawer button locator
Added missing assertion for "Your Cart" title, which mentioned in Issue #34 (Expected: Drawer header should display "Your Cart".)