### PR TITLE
fix(demo): improve use-cases anchor positioning

### DIFF
--- a/apps/demo/src/demo/DemoHome.module.scss
+++ b/apps/demo/src/demo/DemoHome.module.scss
@@ -189,6 +189,7 @@
 
 .section {
   padding: 0;
+  scroll-margin-top: 80px;
 }
 
 .sectionHeader {


### PR DESCRIPTION
## Summary

Fixes the Use Cases navigation positioning issue in the demo application.

## Changes

* Added `scroll-margin-top` to demo sections.
* Prevents the Use Cases section from being partially hidden behind the sticky header when navigating via navbar links.
* Ensures the section heading and content are visible after clicking "Use Cases".

## Testing

* Ran `npm run dev:demo`
* Navigated between Quickstart, Use Cases, and Demo Shop sections
* Verified the Use Cases section is positioned correctly after navigation

Fixes #104
